### PR TITLE
call lightline#highlight in ColorScheme

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -3,7 +3,7 @@
 " Version: 0.0
 " Author: itchyny
 " License: MIT License
-" Last Change: 2013/08/24 13:31:52.
+" Last Change: 2013/08/24 18:23:47.
 " =============================================================================
 
 let s:save_cpo = &cpo
@@ -12,8 +12,9 @@ set cpo&vim
 let s:_ = 1
 let s:is_win32term = (has('win32') || has('win64')) && !has('gui_running')
 
-function! lightline#update()
+function! lightline#update(hi)
   if s:_ | call lightline#init() | endif
+  if a:hi | call lightline#highlight() | endif
   let s = [lightline#statusline(0), lightline#statusline(1)]
   let w = winnr()
   for n in range(1, winnr('$'))

--- a/plugin/lightline.vim
+++ b/plugin/lightline.vim
@@ -3,7 +3,7 @@
 " Version: 0.0
 " Author: itchyny
 " License: MIT License
-" Last Change: 2013/08/24 17:18:13.
+" Last Change: 2013/08/24 18:22:31.
 " =============================================================================
 
 if exists('g:loaded_lightline') && g:loaded_lightline
@@ -15,7 +15,8 @@ set cpo&vim
 
 augroup LightLine
   autocmd!
-  autocmd WinEnter,BufWinEnter,FileType,ColorScheme * call lightline#update()
+  autocmd ColorScheme * call lightline#update(1)
+  autocmd WinEnter,BufWinEnter,FileType * call lightline#update(0)
   autocmd CursorMoved,BufUnload * call lightline#update_once()
 augroup END
 


### PR DESCRIPTION
`lightline#highlight` を呼ばないと `colorscheme` を変えたときに lightline.vim 用の `highlight` がクリアされてしまいました。
