### PR TITLE
Add /doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Add /doc/tags to .gitignore so the repository doesn't get dirty when used as a submodule with pathogen.
