### PR TITLE
correct readonly gylph for powerline-fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ If you have installed the patched font for powerline, use the following settings
 let g:lightline = {
       \ 'colorscheme': 'wombat',
       \ 'component': {
-      \   'readonly': '%{&readonly?"":""}',
+      \   'readonly': '%{&readonly?"":""}',
       \ },
       \ 'separator': { 'left': '', 'right': '' },
       \ 'subseparator': { 'left': '', 'right': '' }


### PR DESCRIPTION
was previously the branching symbol
