### PR TITLE
Update readme to include info about removing extraneous Vim mode info

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,11 @@ let g:lightline = {
     \   'my_component': 'MyComponent', ...
 ```
 
+If you want to get rid of the extraneous default vim mode information that is now provided by liteline:
+```vim
+set noshowmode
+```
+
 This is the end of the tutorial. For more information, see `:help lightline`. Good luck with your nice statuslines.
 
 ### My settings


### PR DESCRIPTION
I noticed I was seeing double when it came to Vim modes:
![screen shot 2014-07-26 at 1 30 42 pm](https://cloud.githubusercontent.com/assets/789890/3712261/c69e3302-1506-11e4-89b6-7ee211a03146.png)

I thought it would be useful to include this configuration setting in your README. Ideally I would like the image to be a part of the README but had some difficulty getting it in the commit because of Github image assets. If you do add this in I think the image would definitely be helpful for the reader.
