### PR TITLE
Add highlight arguments (e.g. bold) support to flatten.

### DIFF
--- a/autoload/lightline/colorscheme.vim
+++ b/autoload/lightline/colorscheme.vim
@@ -211,7 +211,14 @@ function! lightline#colorscheme#flatten(p) abort
   for k in values(a:p)
     for l in values(k)
       for m in range(len(l))
+        let attr = ""
+        if len(l[m]) == 3
+          let attr = l[m][2]
+        endif
         let l[m] = [l[m][0][0], l[m][1][0], l[m][0][1], l[m][1][1]]
+        if !empty(attr)
+          call add(l[m], attr)
+        endif
       endfor
     endfor
   endfor


### PR DESCRIPTION
While adding the [murmur colorscheme](https://camo.githubusercontent.com/f451da06376ea1b857e6480b3f48387d7c30b3cf/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f333239373533392f313231303837362f62616235376461322d323630302d313165332d393130372d3863653735303364363863332e706e67) to lightline, I noticed that highlight arguments like `bold` are not supported when using `flatten()`. This commits solves that (but there may be a more elegant way to write that, my VimL skills are undoubtedly limited :sweat_smile:).

Also, I did not know whether you accepted PR for color schemes so I did not include it, but if you're interested, I can make a PR for that as well.

![murmur](https://cloud.githubusercontent.com/assets/2742231/6173276/eade93aa-b2e6-11e4-86cd-505bc5586a13.png)

