### PR TITLE
Change colour of 'terminal' mode to be same as 'insert' mode. (Close #138)

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -94,7 +94,7 @@ function! lightline#init() abort
         \ 'n': 'normal', 'i': 'insert', 'R': 'replace', 'v': 'visual', 'V': 'visual',
         \ 'c': 'command', "\<C-v>": 'visual', 's': 'select', 'S': 'select', "\<C-s>": 'select',
         \ 't': 'terminal' }
-  call extend(s:lightline.mode_fallback, { 'replace': 'insert', 'select': 'visual' })
+  call extend(s:lightline.mode_fallback, { 'replace': 'insert', 'terminal': 'insert', 'select': 'visual' })
   call extend(s:lightline.component, {
         \ 'mode': '%{lightline#mode()}',
         \ 'absolutepath': '%F', 'relativepath': '%f', 'filename': '%t', 'modified': '%M', 'bufnum': '%n',


### PR DESCRIPTION
Currently the colour of the mode label is the same for normal-mode as for terminal-mode (Neovim only). This makes it harder to tell which mode I currently am in. There is no insert-mode in a terminal buffer and every command that would take the user to insert-mode takes them to terminal-mode instead. With this in mind it makes perfect sense for terminal-mode to have the same colour as insert-mode.

This PR simply assigns the exact same colours to both modes, the colour list for terminal-mode is an exact copy of the list for insert-mode, that way there is no additional maintenance overhead.