### PR TITLE
Support callback from lightline#highlight

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -138,6 +138,7 @@ let s:_lightline = {
       \   },
       \   'mode_fallback': { 'replace': 'insert', 'terminal': 'insert', 'select': 'visual' },
       \   'palette': {},
+      \   'highlight': '',
       \   'winwidth': winwidth(0),
       \ }
 function! lightline#init() abort
@@ -185,10 +186,12 @@ endfunction
 function! lightline#colorscheme() abort
   try
     let s:lightline.palette = g:lightline#colorscheme#{s:lightline.colorscheme}#palette
+    let s:lightline.highlight = 'lightline#colorscheme#' . s:lightline.colorscheme . '#highlight'
   catch
     call lightline#error('Could not load colorscheme ' . s:lightline.colorscheme . '.')
     let s:lightline.colorscheme = 'default'
     let s:lightline.palette = g:lightline#colorscheme#{s:lightline.colorscheme}#palette
+    let s:lightline.highlight = 'lightline#colorscheme#' . s:lightline.colorscheme . '#highlight'
   finally
     let s:highlight = {}
     call lightline#highlight('normal')
@@ -289,6 +292,9 @@ function! lightline#highlight(...) abort
       endfor
     endfor
     exec printf('hi LightLineMiddle_%s guifg=%s guibg=%s ctermfg=%s ctermbg=%s %s', mode, ms[0], ms[1], ms[2], ms[3], s:term(ms))
+    if exists('*'.s:lightline.highlight)
+      silent! call call(s:lightline.highlight, [mode])
+    endif
   endfor
 endfunction
 

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -616,6 +616,15 @@ compiled version of your colorscheme.
 <
 Then copy and paste the result to the colorscheme file.
 
+A colorscheme may register a callback to be notified when lightline changes
+highlighting. This optional feature can be used to create reactive colorschemes.
+To enable this feature, a function that accepts a single argument for the
+current mode should be defined as follows:
+>
+	function! lightline#colorscheme#yourcolorscheme#highlight(mode)
+	  ...
+	endfunction
+<
 ==============================================================================
 EXAMPLES					*lightline-examples*
 You can configure the appearance of statusline.


### PR DESCRIPTION
This PR adds support for a colorscheme to optionally receive a callback when lightline changes highlighting. This can be used to permit a colorscheme to change unrelated highlight groups when the plugin is loaded, or the mode is changed.

For more detail, see issue: #179 