### PR TITLE
Add Dracula theme

### DIFF
--- a/autoload/lightline/colorscheme/Dracula.vim
+++ b/autoload/lightline/colorscheme/Dracula.vim
@@ -1,0 +1,38 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/Dracula.vim
+" Author: itchyny
+" License: MIT License
+" Last Change: 2016/10/13 01:51:38.
+" =============================================================================
+
+let s:black = '#282a36'
+let s:gray = '#44475a'
+let s:white = '#f8f8f2'
+let s:darkblue = '#6272a4'
+let s:cyan = '#8be9fd'
+let s:green = '#50fa7b'
+let s:orange = '#ffb86c'
+let s:pink = '#ff79c6'
+let s:purple = '#bd93f9'
+let s:red = '#ff5555'
+let s:yellow = '#f1fa8c'
+
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:black, s:purple ], [ s:cyan, s:gray ] ]
+let s:p.normal.right = [ [ s:black, s:purple ], [ s:white, s:darkblue ] ]
+let s:p.inactive.right = [ [ s:black, s:gray ], [ s:white, s:black ] ]
+let s:p.inactive.left =  [ [ s:cyan, s:black ], [ s:white, s:black ] ]
+let s:p.insert.left = [ [ s:black, s:green ], [ s:cyan, s:gray ] ]
+let s:p.replace.left = [ [ s:black, s:red ], [ s:cyan, s:gray ] ]
+let s:p.visual.left = [ [ s:black, s:orange ], [ s:cyan, s:gray ] ]
+let s:p.normal.middle = [ [ s:white, s:gray ] ]
+let s:p.inactive.middle = [ [ s:white, s:gray ] ]
+let s:p.tabline.left = [ [ s:darkblue, s:gray ] ]
+let s:p.tabline.tabsel = [ [ s:cyan, s:black ] ]
+let s:p.tabline.middle = [ [ s:darkblue, s:gray ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:red, s:black ] ]
+let s:p.normal.warning = [ [ s:yellow, s:black ] ]
+
+let g:lightline#colorscheme#Dracula#palette = lightline#colorscheme#fill(s:p)

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -223,7 +223,7 @@ OPTIONS						*lightline-option*
 		The colorscheme for lightline.vim.
 		Currently, wombat, solarized, powerline, jellybeans, Tomorrow,
 		Tomorrow_Night, Tomorrow_Night_Blue, Tomorrow_Night_Eighties,
-		PaperColor, seoul256, landscape and 16color are available.
+		PaperColor, seoul256, landscape, Dracula, and 16color are available.
 		The default value is:
 >
 		let g:lightline.colorscheme = 'default'


### PR DESCRIPTION
Based on the [Dracula Theme](https://draculatheme.com/), which has become fairly popular and supports a large number of editors.

Screenshot:
![lightline_dracula_screenshot](https://cloud.githubusercontent.com/assets/180203/19360929/93e1432a-914e-11e6-8bb7-8bdaccdc0541.png)

Mode comparison screenshots (I wasn't sure how to add this to the README)
![dracula_lightline_mode_comparison](https://cloud.githubusercontent.com/assets/180203/19360943/a03c5f38-914e-11e6-94d4-4be297c6e2e0.png)