### PR TITLE
Include short mode mappings for small windows

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -128,6 +128,10 @@ let s:_lightline = {
       \     'n': 'NORMAL', 'i': 'INSERT', 'R': 'REPLACE', 'v': 'VISUAL', 'V': 'V-LINE', "\<C-v>": 'V-BLOCK',
       \     'c': 'COMMAND', 's': 'SELECT', 'S': 'S-LINE', "\<C-s>": 'S-BLOCK', 't': 'TERMINAL'
       \   },
+      \   'short_mode_map': {
+      \     'n': 'N', 'i': 'I', 'R': 'R', 'v': 'V', 'V': 'V', 'c': 'C',
+      \     "\<C-v>": 'V', 's': 'S', 'S': 'S', "\<C-s>": 'S', 't': 'T'
+      \   },
       \   'separator': { 'left': '', 'right': '' },
       \   'subseparator': { 'left': '|', 'right': '|' },
       \   'tabline_separator': {},
@@ -213,6 +217,10 @@ endfunction
 
 function! lightline#mode() abort
   return get(s:lightline.mode_map, mode(), '')
+endfunction
+
+function! lightline#shortmode() abort
+  return get(s:lightline.short_mode_map, mode(), '')
 endfunction
 
 let s:mode = ''


### PR DESCRIPTION
This is simple way of only using mode letters once the buffer window is below a certain width. (Possibly when shrinking the terminal window itself, but more commonly when using something like [Tmux](https://tmux.github.io/), which allows for arbitrarily-sized shell panes to be open in the same window.)

It allows for a cleaner responsive design in my opinion. I use it as a component function that looks something like this:

```vim
      \ 'component_function': {
      \   'mode': 'LightLineMode',
      \   ...
      \ }

function! LightLineMode()
  return winwidth(0) > 30 ? lightline#mode() : lightline#shortmode()
endfunction
```

Here is an example of how it would play out as the window shrinks to a small size:

<img width="584" alt="screen shot 2016-10-23 at 1 42 07 am" src="https://cloud.githubusercontent.com/assets/3409645/19625106/e979e252-98c3-11e6-8b1f-91de5c73a6ca.png">
<img width="504" alt="screen shot 2016-10-23 at 1 42 36 am" src="https://cloud.githubusercontent.com/assets/3409645/19625105/e9799dd8-98c3-11e6-9bbe-8ba1489aaa14.png">
<img width="303" alt="screen shot 2016-10-23 at 1 57 08 am" src="https://cloud.githubusercontent.com/assets/3409645/19625115/12cdb822-98c4-11e6-8c4f-c692c9a82a2c.png">
<img width="224" alt="screen shot 2016-10-23 at 1 55 48 am" src="https://cloud.githubusercontent.com/assets/3409645/19625117/30975a2a-98c4-11e6-90c6-f21056fd85aa.png">

Not a terribly complex feature obviously, but it's been a nice add-on for me to keep the lightline from looking too squished at any size.

Let me know what you think! Love the plugin, thanks for making it 💛 