### PR TITLE
Update links to alternative plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ landscape is my colorscheme, which is a high-contrast cui-supported colorscheme,
 
 ## Why yet another clone of powerline?
 + [vim-powerline](https://github.com/Lokaltog/vim-powerline) is a nice plugin, but deprecated.
-+ [powerline](https://github.com/Lokaltog/powerline) is a nice plugin, but difficult to configure.
-+ [vim-airline](https://github.com/bling/vim-airline) is a nice plugin, but it uses too much functions of other plugins, which should be done by users in `.vimrc`.
++ [powerline](https://github.com/powerline/powerline) is a nice plugin, but difficult to configure.
++ [vim-airline](https://github.com/vim-airline/vim-airline) is a nice plugin, but it uses too much functions of other plugins, which should be done by users in `.vimrc`.
 
 ## Spirit of this plugin
 + Minimalism. The core script is very small to achive enough functions as a statusline plugin.


### PR DESCRIPTION
The previous links still worked, but were redirecting to the new location for these repos. I updated them to go directly to the end destination.