### PR TITLE
Add Nord color scheme

### DIFF
--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -5,7 +5,6 @@
 " Last Change: 2017/11/12 20:27:51
 " =============================================================================
 
-let s:nord_vim_version="0.6.0"
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
 let s:nord0 = ["#2E3440", "NONE"]

--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -1,0 +1,47 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/nord.vim
+" Author: arcticicestudio
+" License: Apache 2.0
+" Last Change: 2017/08/03 09:14:52
+" =============================================================================
+
+let s:nord_vim_version="0.6.0"
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+
+let s:nord0 = ["#2E3440", "NONE"]
+let s:nord1 = ["#3B4252", 0]
+let s:nord2 = ["#434C5E", "NONE"]
+let s:nord3 = ["#4C566A", 8]
+let s:nord4 = ["#D8DEE9", "NONE"]
+let s:nord5 = ["#E5E9F0", 7]
+let s:nord6 = ["#ECEFF4", 15]
+let s:nord7 = ["#8FBCBB", 14]
+let s:nord8 = ["#88C0D0", 6]
+let s:nord9 = ["#81A1C1", 4]
+let s:nord10 = ["#5E81AC", 12]
+let s:nord11 = ["#BF616A", 1]
+let s:nord12 = ["#D08770", 11]
+let s:nord13 = ["#EBCB8B", 3]
+let s:nord14 = ["#A3BE8C", 2]
+let s:nord15 = ["#B48EAD", 5]
+
+let s:p.normal.left = [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
+let s:p.normal.middle = [ [ s:nord5, s:nord3 ] ]
+let s:p.normal.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
+let s:p.normal.warning = [ [ s:nord1, s:nord13 ] ]
+let s:p.normal.error = [ [ s:nord1, s:nord11 ] ]
+
+let s:p.inactive.left =  [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
+let s:p.inactive.middle = [ [ s:nord5, s:nord0 ] ]
+let s:p.inactive.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
+
+let s:p.insert.left = [ [ s:nord1, s:nord6 ], [ s:nord5, s:nord1 ] ]
+let s:p.replace.left = [ [ s:nord1, s:nord13 ], [ s:nord5, s:nord1 ] ]
+let s:p.visual.left = [ [ s:nord1, s:nord7 ], [ s:nord5, s:nord1 ] ]
+
+let s:p.tabline.left = [ [ s:nord5, s:nord3 ] ]
+let s:p.tabline.middle = [ [ s:nord5, s:nord3 ] ]
+let s:p.tabline.right = [ [ s:nord5, s:nord3 ] ]
+let s:p.tabline.tabsel = [ [ s:nord1, s:nord8 ] ]
+
+let g:lightline#colorscheme#nord#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -1,8 +1,8 @@
 " =============================================================================
 " Filename: autoload/lightline/colorscheme/nord.vim
 " Author: arcticicestudio
-" License: Apache 2.0
-" Last Change: 2017/08/03 09:14:52
+" License: MIT
+" Last Change: 2017/11/12 20:27:51
 " =============================================================================
 
 let s:nord_vim_version="0.6.0"

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -229,7 +229,7 @@ OPTIONS						*lightline-option*
 		Currently, wombat, solarized, powerline, jellybeans, Tomorrow,
 		Tomorrow_Night, Tomorrow_Night_Blue, Tomorrow_Night_Eighties,
 		PaperColor, seoul256, landscape, one, Dracula, darcula,
-		Molokai, materia, material, OldHope and 16color are available.
+		Molokai, materia, material, OldHope, Nord and 16color are available.
 		The default value is:
 >
 		let g:lightline.colorscheme = 'default'


### PR DESCRIPTION
<p align="center"><img src="https://cdn.rawgit.com/arcticicestudio/nord-vim/develop/assets/nord-vim-banner.svg"/></p>

Added the [Nord Vim][nord-vim] lightline color scheme. It is also shipped with Nord Vim, but adding it to lightline itself might simplify the usage for some users. The comment header has been changed to adapt to the already included color schemes.

Mentioned in arcticicestudio/nord-vim#68 by @lokesh-krishna

![][preview]
![][hero]

[nord-vim]: https://github.com/arcticicestudio/nord-vim
[hero]: https://raw.githubusercontent.com/arcticicestudio/nord-vim/develop/assets/scrot-lang-javascript.png
[preview]: https://raw.githubusercontent.com/arcticicestudio/nord-vim/develop/assets/scrot-plugin-support-ui-lightline.png