### PR TITLE
Fix invisible inactive bar for "nord" color scheme

### DIFF
--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -31,7 +31,7 @@ let s:p.normal.warning = [ [ s:nord1, s:nord13 ] ]
 let s:p.normal.error = [ [ s:nord1, s:nord11 ] ]
 
 let s:p.inactive.left =  [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
-let s:p.inactive.middle = [ [ s:nord5, s:nord0 ] ]
+let s:p.inactive.middle = [ [ s:nord5, s:nord1 ] ]
 let s:p.inactive.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
 
 let s:p.insert.left = [ [ s:nord1, s:nord6 ], [ s:nord5, s:nord1 ] ]


### PR DESCRIPTION
> Related to arcticicestudio/nord-vim#73

Fixes the middle element of inactive bars for the *nord* color scheme caused by arcticicestudio/nord-vim#58.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/33611233-ee956b8e-d9cd-11e7-8c25-ae78d44032f1.png"/><br><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/33611237-f42a0424-d9cd-11e7-825a-8056accf7b03.png"/></p>