### PR TITLE
Highlight separators between all components

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -233,7 +233,7 @@ function! lightline#link(...) abort
         exec printf('hi link Lightline%s_active_%s Lightline%s_%s_%s', p, i, p, mode, i)
       endif
       for [j, s] in map(range(0, l), '[v:val, 0]') + types
-        if i + 1 == j || t || s && i != l
+        if i + 1 <= j || t || s && i != l
           exec printf('hi link Lightline%s_active_%s_%s Lightline%s_%s_%s_%s', p, i, j, p, mode, i, j)
         endif
       endfor
@@ -283,7 +283,7 @@ function! lightline#highlight(...) abort
           exec printf('hi Lightline%s_%s_%s guifg=%s guibg=%s ctermfg=%s ctermbg=%s %s', p, mode, i, r[0], r[1], r[2], r[3], s:term(r))
         endif
         for [j, s] in map(range(0, l), '[v:val, 0]') + types
-          if i + 1 == j || t || s && i != l
+          if i + 1 <= j || t || s && i != l
             let q = s ? (has_key(get(c, d, []), j) ? c[d][j][0] : has_key(get(c, 'tabline', {}), j) ? c.tabline[j][0] : get(c.normal, j, zs)[0]) : (j != l ? get(zs, j, ms) :ms)
             exec printf('hi Lightline%s_%s_%s_%s guifg=%s guibg=%s ctermfg=%s ctermbg=%s', p, mode, i, j, r[1], q[1], r[3], q[3])
           endif


### PR DESCRIPTION
This PR allows the creation of the separator highlightings between all combinations of components.

This is required to allow components surrounding a hidden expanding component (declared in `component_expand`) to have the correct highlighting on the separator between them.

Before:
![screenshot-2018-02-12t23 45 31-0200](https://user-images.githubusercontent.com/6091633/36130320-6407c52c-1053-11e8-8b31-8af9f073399b.png)

After:
![screenshot-2018-02-13t00 18 43-0200](https://user-images.githubusercontent.com/6091633/36130341-774bc2a0-1053-11e8-80a4-8b86fadd9680.png)

Fixes #289.