### PR TITLE
10 AtelierSchemes themed colorschemes for Lightline

### DIFF
--- a/autoload/lightline/colorscheme/Atelier_Cave.vim
+++ b/autoload/lightline/colorscheme/Atelier_Cave.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Cave.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Cave.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '240   ', 'LightGreen' ],
+      \ 'base00': [ '11', '241   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '243   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '245   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '130   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '131   ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '164   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '99    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '63    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '67    ', 'DarkCyan' ],
+      \ 'green': [ '2', '30    ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Cave uses to determine which set of colors
+" to use.
+let s:Atelier_Cave_termcolors = get(g:, 'Atelier_Cave_termcolors', 256)
+if s:Atelier_Cave_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Cave_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#19171c', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#26232a', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#585260', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#655f6d', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#7e7887', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#8b8792', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#e2dfe7', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#efecf4', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#a06e3b', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#aa573c', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#be4678', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#bf40bf', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#955ae7', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#576ddb', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#398bc6', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#2a9292', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Cave#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Dune.vim
+++ b/autoload/lightline/colorscheme/Atelier_Dune.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Dune.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Dune.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '242   ', 'LightGreen' ],
+      \ 'base00': [ '11', '244   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '246   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '248   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '136   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '130   ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '161   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '135   ', 'LightMagenta' ],
+      \ 'blue': [ '4', '69    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '36    ', 'DarkCyan' ],
+      \ 'green': [ '2', '70    ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Dune uses to determine which set of colors
+" to use.
+let s:Atelier_Dune_termcolors = get(g:, 'Atelier_Dune_termcolors', 256)
+if s:Atelier_Dune_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Dune_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#20201d', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#292824', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#6e6b5e', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#7d7a68', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#999580', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#a6a28c', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#e8e4cf', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#fefbec', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#ae9513', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#b65611', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#d73737', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#d43552', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#b854d4', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#6684e1', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#1fad83', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#60ac39', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Dune#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Estuary.vim
+++ b/autoload/lightline/colorscheme/Atelier_Estuary.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Estuary.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Estuary.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '235   ', 'DarkGray' ],
+      \ 'base02': [ '0', '236   ', 'Black' ],
+      \ 'base01': [ '10', '240   ', 'LightGreen' ],
+      \ 'base00': [ '11', '242   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '245   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '246   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '142   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '137   ', 'LightRed' ],
+      \ 'red': [ '1', '235   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '132   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '66    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '36    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '71    ', 'DarkCyan' ],
+      \ 'green': [ '2', '100   ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Estuary uses to determine which set of colors
+" to use.
+let s:Atelier_Estuary_termcolors = get(g:, 'Atelier_Estuary_termcolors', 256)
+if s:Atelier_Estuary_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Estuary_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#22221b', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#302f27', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#5f5e4e', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#6c6b5a', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#878573', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#929181', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#e7e6df', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#f4f3ec', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#a5980d', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#ae7313', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#ba6236', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#9d6c7c', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#5f9182', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#36a166', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#5b9d48', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#7d9726', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Estuary#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Forest.vim
+++ b/autoload/lightline/colorscheme/Atelier_Forest.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Forest.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Forest.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '241   ', 'LightGreen' ],
+      \ 'base00': [ '11', '242   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '246   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '247   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '137   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '166   ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '63    ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '99    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '69    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '67    ', 'DarkCyan' ],
+      \ 'green': [ '2', '100   ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Forest uses to determine which set of colors
+" to use.
+let s:Atelier_Forest_termcolors = get(g:, 'Atelier_Forest_termcolors', 256)
+if s:Atelier_Forest_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Forest_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#1b1918', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#2c2421', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#68615e', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#766e6b', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#9c9491', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#a8a19f', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#e6e2e0', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#f1efee', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#c38418', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#df5320', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#f22c40', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#c33ff3', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#6666ea', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#407ee7', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#3d97b8', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#7b9726', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Forest#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Heath.vim
+++ b/autoload/lightline/colorscheme/Atelier_Heath.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Heath.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Heath.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '241   ', 'LightGreen' ],
+      \ 'base00': [ '11', '242   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '245   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '247   ', 'LightCyan' ],
+      \ 'base2': [ '7', '253   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '137   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '130   ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '164   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '98    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '63    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '30    ', 'DarkCyan' ],
+      \ 'green': [ '2', '100   ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Heath uses to determine which set of colors
+" to use.
+let s:Atelier_Heath_termcolors = get(g:, 'Atelier_Heath_termcolors', 256)
+if s:Atelier_Heath_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Heath_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#1b181b', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#292329', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#695d69', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#776977', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#9e8f9e', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#ab9bab', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#d8cad8', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#f7f3f7', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#bb8a35', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#a65926', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#ca402b', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#cc33cc', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#7b59c0', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#516aec', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#159393', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#918b3b', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Heath#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Lakeside.vim
+++ b/autoload/lightline/colorscheme/Atelier_Lakeside.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Lakeside.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Lakeside.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '241   ', 'LightGreen' ],
+      \ 'base00': [ '11', '243   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '246   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '247   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '100   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '94    ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '164   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '61    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '31    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '29    ', 'DarkCyan' ],
+      \ 'green': [ '2', '65    ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Lakeside uses to determine which set of colors
+" to use.
+let s:Atelier_Lakeside_termcolors = get(g:, 'Atelier_Lakeside_termcolors', 256)
+if s:Atelier_Lakeside_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Lakeside_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#161b1d', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#1f292e', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#516d7b', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#5a7b8c', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#7195a8', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#7ea2b4', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#c1e4f6', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#ebf8ff', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#8a8a0f', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#935c25', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#d22d72', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#b72dd2', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#6b6bb8', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#257fad', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#2d8f6f', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#568c3b', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Lakeside#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Plateau.vim
+++ b/autoload/lightline/colorscheme/Atelier_Plateau.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Plateau.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Plateau.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '240   ', 'LightGreen' ],
+      \ 'base00': [ '11', '241   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '243   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '245   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '137   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '130   ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '132   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '98    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '69    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '67    ', 'DarkCyan' ],
+      \ 'green': [ '2', '66    ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Plateau uses to determine which set of colors
+" to use.
+let s:Atelier_Plateau_termcolors = get(g:, 'Atelier_Plateau_termcolors', 256)
+if s:Atelier_Plateau_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Plateau_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#1b1818', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#292424', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#585050', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#655d5d', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#7e7777', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#8a8585', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#e7dfdf', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#f4ecec', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#a06e3b', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#b45a3c', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#ca4949', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#bd5187', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#8464c4', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#7272ca', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#5485b6', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#4b8b8b', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Plateau#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Savanna.vim
+++ b/autoload/lightline/colorscheme/Atelier_Savanna.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Savanna.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Savanna.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '240   ', 'LightGreen' ],
+      \ 'base00': [ '11', '242   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '245   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '246   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '136   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '130   ', 'LightRed' ],
+      \ 'red': [ '1', '234   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '95    ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '67    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '66    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '30    ', 'DarkCyan' ],
+      \ 'green': [ '2', '65    ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Savanna uses to determine which set of colors
+" to use.
+let s:Atelier_Savanna_termcolors = get(g:, 'Atelier_Savanna_termcolors', 256)
+if s:Atelier_Savanna_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Savanna_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#171c19', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#232a25', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#526057', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#5f6d64', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#78877d', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#87928a', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#dfe7e2', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#ecf4ee', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#a07e3b', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#9f713c', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#b16139', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#867469', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#55859b', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#478c90', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#1c9aa0', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#489963', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Savanna#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Seaside.vim
+++ b/autoload/lightline/colorscheme/Atelier_Seaside.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Seaside.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Seaside.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '233   ', 'DarkGray' ],
+      \ 'base02': [ '0', '235   ', 'Black' ],
+      \ 'base01': [ '10', '242   ', 'LightGreen' ],
+      \ 'base00': [ '11', '244   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '246   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '249   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '136   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '94    ', 'LightRed' ],
+      \ 'red': [ '1', '233   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '129   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '67    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '69    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '31    ', 'DarkCyan' ],
+      \ 'green': [ '2', '34    ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Seaside uses to determine which set of colors
+" to use.
+let s:Atelier_Seaside_termcolors = get(g:, 'Atelier_Seaside_termcolors', 256)
+if s:Atelier_Seaside_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Seaside_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#131513', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#242924', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#5e6e5e', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#687d68', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#809980', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#8ca68c', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#cfe8cf', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#f4fbf4', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#98981b', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#87711d', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#e6193c', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#e619c3', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#ad2bee', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#3d62f5', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#1999b3', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#29a329', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Seaside#palette = lightline#colorscheme#flatten(s:p)
+

--- a/autoload/lightline/colorscheme/Atelier_Sulphurpool.vim
+++ b/autoload/lightline/colorscheme/Atelier_Sulphurpool.vim
@@ -1,0 +1,78 @@
+" Filename: Atelier_Sulphurpool.vim (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/autoload/lightline/colorscheme/Atelier_Sulphurpool.vim)
+" Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)
+" License: MIT License
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '235   ', 'DarkGray' ],
+      \ 'base02': [ '0', '236   ', 'Black' ],
+      \ 'base01': [ '10', '241   ', 'LightGreen' ],
+      \ 'base00': [ '11', '243   ', 'LightYellow' ],
+      \ 'base0':  [ '12', '246   ', 'LightBlue' ],
+      \ 'base1':  [ '14', '247   ', 'LightCyan' ],
+      \ 'base2': [ '7', '254   ', 'LightGray' ],
+      \ 'base3': [ '15', '231   ', 'White' ],
+      \ 'yellow': [ '3', '137   ', 'DarkYellow' ],
+      \ 'orange': [ '9', '166   ', 'LightRed' ],
+      \ 'red': [ '1', '235   ', 'DarkRed' ],
+      \ 'magenta': [ '5', '133   ', 'DarkMagenta' ],
+      \ 'violet': [ '13', '69    ', 'LightMagenta' ],
+      \ 'blue': [ '4', '67    ', 'DarkBlue' ],
+      \ 'cyan': [ '6', '38    ', 'DarkCyan' ],
+      \ 'green': [ '2', '136   ', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-Atelier_Sulphurpool uses to determine which set of colors
+" to use.
+let s:Atelier_Sulphurpool_termcolors = get(g:, 'Atelier_Sulphurpool_termcolors', 256)
+if s:Atelier_Sulphurpool_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:Atelier_Sulphurpool_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#202746', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#293256', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#5e6687', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#6b7394', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#898ea4', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#979db4', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#dfe2f1', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#f5f7ff', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#c08b30', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#c76b29', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#c94922', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#9c637a', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#6679cc', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#3d8fd1', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#22a2c9', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#ac9739', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#Atelier_Sulphurpool#palette = lightline#colorscheme#flatten(s:p)
+


### PR DESCRIPTION
Because [AtelierSchemes colorschemes](http://atelierbram.github.io/syntax-highlighting/atelier-schemes/) are based on Solarized, it made sense to adjust the template found in this repo for the Lightline colorscheme with that same name. And just like the Solarized template, these also pick up if a light or dark background is set and automagically adjusts after reloading Vim.
These AtelierSchemes colorschemes for Lightline will look most harmonious together with the equivalent [AtelierSchemes color theme for Vim](https://github.com/atelierbram/vim-colors_atelier-schemes) (_, but obviously can be used alongside any other Vim colorscheme_).  