### PR TITLE
Move lightline augroup declarations into an autoload function

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -10,6 +10,17 @@ set cpo&vim
 
 let s:_ = 1
 
+function! lightline#augroup() abort
+    augroup lightline
+      autocmd!
+      autocmd WinEnter,BufWinEnter,FileType,SessionLoadPost * call lightline#update()
+      autocmd SessionLoadPost * call lightline#highlight()
+      autocmd ColorScheme * if !has('vim_starting') || expand('<amatch>') !=# 'macvim'
+            \ | call lightline#update() | call lightline#highlight() | endif
+      autocmd CursorMoved,BufUnload * call lightline#update_once()
+    augroup END
+endfunction
+
 function! lightline#update() abort
   if s:_
     call lightline#init()
@@ -45,14 +56,7 @@ function! lightline#enable() abort
   if s:lightline.enable.tabline
     set tabline=%!lightline#tabline()
   endif
-  augroup lightline
-    autocmd!
-    autocmd WinEnter,BufWinEnter,FileType,SessionLoadPost * call lightline#update()
-    autocmd SessionLoadPost * call lightline#highlight()
-    autocmd ColorScheme * if !has('vim_starting') || expand('<amatch>') !=# 'macvim'
-          \ | call lightline#update() | call lightline#highlight() | endif
-    autocmd CursorMoved,BufUnload * call lightline#update_once()
-  augroup END
+  call lightline#augroup()
   augroup lightline-disable
     autocmd!
   augroup END

--- a/plugin/lightline.vim
+++ b/plugin/lightline.vim
@@ -13,14 +13,7 @@ let g:loaded_lightline = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-augroup lightline
-  autocmd!
-  autocmd WinEnter,BufWinEnter,FileType,SessionLoadPost * call lightline#update()
-  autocmd SessionLoadPost * call lightline#highlight()
-  autocmd ColorScheme * if !has('vim_starting') || expand('<amatch>') !=# 'macvim'
-        \ | call lightline#update() | call lightline#highlight() | endif
-  autocmd CursorMoved,BufUnload * call lightline#update_once()
-augroup END
+call lightline#augroup()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
This PR simply moves the definition of the `lightline` augroup to an autoload function `lightline#augroup()`, so any necessary changes need only be made in that one spot.