### PR TITLE
Treat nvim with termguicolors enabled as if it was a gui client

### DIFF
--- a/autoload/lightline/colorscheme.vim
+++ b/autoload/lightline/colorscheme.vim
@@ -224,7 +224,7 @@ function! lightline#colorscheme#flatten(p) abort
   return a:p
 endfunction
 
-if has('gui_running')
+if has('gui_running') || ( has('nvim') && &termguicolors )
   function! lightline#colorscheme#background() abort
     return &background
   endfunction


### PR DESCRIPTION
This helps set the correct light/dark background value within lightline.