### PR TITLE
Allow to customize status line in terminal windows

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -102,8 +102,8 @@ let s:_lightline = {
       \     'right': [['lineinfo'], ['percent']]
       \   },
       \   'terminal': {
-      \     'left': [['mode', 'paste'], ['readonly', 'filename', 'modified']],
-      \     'right': [['lineinfo'], ['percent'], ['fileformat', 'fileencoding', 'filetype']]
+      \     'left': [['mode', 'paste'], ['termtitle']],
+      \     'right': [['buftype']]
       \   },
       \   'tabline': {
       \     'left': [['tabs']],
@@ -119,7 +119,8 @@ let s:_lightline = {
       \     'paste': '%{&paste?"PASTE":""}', 'readonly': '%R', 'charvalue': '%b', 'charvaluehex': '%B',
       \     'spell': '%{&spell?&spelllang:""}', 'fileencoding': '%{&fenc!=#""?&fenc:&enc}', 'fileformat': '%{&ff}',
       \     'filetype': '%{&ft!=#""?&ft:"no ft"}', 'percent': '%3p%%', 'percentwin': '%P',
-      \     'lineinfo': '%3l:%-2v', 'line': '%l', 'column': '%c', 'close': '%999X X ', 'winnr': '%{winnr()}'
+      \     'lineinfo': '%3l:%-2v', 'line': '%l', 'column': '%c', 'close': '%999X X ', 'winnr': '%{winnr()}',
+      \     'termtitle': '%{term_gettitle("%")}', 'buftype': '%{&bt!=#""?&bt:"no bt"}'
       \   },
       \   'component_visible_condition': {
       \     'modified': '&modified||!&modifiable', 'readonly': '&readonly', 'paste': '&paste', 'spell': '&spell'

--- a/plugin/lightline.vim
+++ b/plugin/lightline.vim
@@ -15,7 +15,7 @@ set cpo&vim
 
 augroup lightline
   autocmd!
-  autocmd WinEnter,BufWinEnter,FileType,SessionLoadPost * call lightline#update()
+  autocmd WinEnter,BufWinEnter,FileType,SessionLoadPost,TerminalOpen * call lightline#update()
   autocmd SessionLoadPost * call lightline#highlight()
   autocmd ColorScheme * if !has('vim_starting') || expand('<amatch>') !=# 'macvim'
         \ | call lightline#update() | call lightline#highlight() | endif


### PR DESCRIPTION
## Motivation

* `readonly`, `filename`, `modified`... They're boring in terminal windows.
* In there, I want to see other informations in the terminal.

## Change point

* Add a new configuration parameter `g:lightline.terminal` like `g:lightline.active` and `g:lightline.inactive`
* Change a function `lightline#statusline(inactive)` that it can receive `terminal` parameter.
* Hook a new event `TerminalOpen` to update lightline status.
* Add new useful components, `termtitle` and `buftype` for terminal mode.