### PR TITLE
Allow custom statusline on a per-window basis

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -22,8 +22,10 @@ function! lightline#update() abort
   let w = winnr()
   let s = winnr('$') == 1 ? [lightline#statusline(0)] : [lightline#statusline(0), lightline#statusline(1)]
   for n in range(1, winnr('$'))
-    call setwinvar(n, '&statusline', s[n!=w])
-    call setwinvar(n, 'lightline', n!=w)
+    if !getwinvar(n, 'lightline_ignore', 0)
+      call setwinvar(n, '&statusline', s[n!=w])
+      call setwinvar(n, 'lightline', n!=w)
+    endif
   endfor
 endfunction
 


### PR DESCRIPTION
By setting w:lightline_ignore to 1, lightline will skip the window when updating.