### PR TITLE
Add powerlineish theme

### DIFF
--- a/autoload/lightline/colorscheme/powerlineish.vim
+++ b/autoload/lightline/colorscheme/powerlineish.vim
@@ -1,0 +1,28 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/powerline.vim
+" Author: itchyny
+" License: MIT License
+" Last Change: 2013/09/07 15:54:41.
+" =============================================================================
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ ['darkestgreen', 'brightgreen', 'bold'], ['white', 'gray0'] ]
+let s:p.normal.right = [ ['gray10', 'gray2'], ['white', 'gray1'], ['white', 'gray0'] ]
+let s:p.inactive.right = [ ['gray1', 'gray5'], ['gray4', 'gray1'], ['gray4', 'gray0'] ]
+let s:p.inactive.left = s:p.inactive.right[1:]
+let s:p.insert.left = [ ['darkestcyan', 'white', 'bold'], ['mediumcyan', 'darkestblue'] ]
+let s:p.insert.right = [ [ 'darkestblue', 'mediumcyan' ], [ 'mediumcyan', 'darkblue' ], [ 'mediumcyan', 'darkestblue' ] ]
+let s:p.replace.left = [ ['white', 'brightred', 'bold'], ['white', 'gray0'] ]
+let s:p.visual.left = [ ['black', 'brightestorange', 'bold'], ['white', 'gray0'] ]
+let s:p.normal.middle = [ [ 'white', 'gray0' ] ]
+let s:p.insert.middle = [ [ 'mediumcyan', 'darkestblue' ] ]
+let s:p.replace.middle = s:p.normal.middle
+let s:p.replace.right = s:p.normal.right
+let s:p.tabline.left = [ [ 'gray9', 'gray0' ] ]
+let s:p.tabline.tabsel = [ [ 'gray9', 'gray2' ] ]
+let s:p.tabline.middle = [ [ 'gray2', 'gray0' ] ]
+let s:p.tabline.right = [ [ 'gray9', 'gray1' ] ]
+let s:p.normal.error = [ [ 'gray9', 'brightestred' ] ]
+let s:p.normal.warning = [ [ 'gray1', 'yellow' ] ]
+
+let g:lightline#colorscheme#powerlineish#palette = lightline#colorscheme#fill(s:p)


### PR DESCRIPTION
This adds theme based on [powerlineish](https://github.com/vim-airline/vim-airline-themes/blob/master/autoload/airline/themes/powerlineish.vim) which has nice features:

1. Colors are arranged in gradients
2. Less colors overall are used, feels more minimalistic
3. Vim looks more like terminal prompt

Here's screencast showing it with my column settings:
https://asciinema.org/a/0GBtlPlSMezpBgnRK99uHRpe1

And here's with default column settings:
https://asciinema.org/a/Cng6Tn3iyxvumgBTdW4qC6sW2
