### PR TITLE
Entering a popup window, do not update lightline

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -11,6 +11,9 @@ set cpo&vim
 let s:_ = 1 " 1: uninitialized, 2: disabled
 
 function! lightline#update() abort
+  if &buftype == 'popup'
+      return
+  endif
   if s:_
     if s:_ == 2 | return | endif
     call lightline#init()


### PR DESCRIPTION
## Problem
Setting a filetype in a popup window, an error occurs.

## Procedure

1. `gvim -u NONE -N`
2. `:source a.vim`

```vim:
" a.vim
set runtimepath+=~/.vim/pack/my/start/lightline.vim
filetype plugin indent on
set laststatus=2
call lightline#enable()
call win_execute(popup_menu(['aaa', 'bbb'], {}), 'setfiletype vim')
```

3. throw a exception
![a](https://user-images.githubusercontent.com/1595779/61187289-bf8f4700-a6aa-11e9-84d4-efe77bd709f9.jpg)


