### PR TITLE
add comprehensive colorscheme screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,48 +5,50 @@ https://github.com/itchyny/lightline.vim
 
 ### powerline (default)
 
-![lightline.vim - powerline](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/powerline.png)
+![lightline.vim - powerline](../../wiki/image/powerline.png)
 
 ### wombat
 
-![lightline.vim - wombat](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/wombat.png)
+![lightline.vim - wombat](../../wiki/image/wombat.png)
 
 ### jellybeans
 
-![lightline.vim - jellybeans](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/jellybeans.png)
+![lightline.vim - jellybeans](../../wiki/image/jellybeans.png)
 
 ### solarized dark
 
-![lightline.vim - solarized_dark](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/solarized_dark.png)
+![lightline.vim - solarized_dark](../../wiki/image/solarized_dark.png)
 
 ### solarized light
 
-![lightline.vim - solarized_light](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/solarized_light.png)
+![lightline.vim - solarized_light](../../wiki/image/solarized_light.png)
 
 ### PaperColor light
 
-![lightline.vim - PaperColor](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/PaperColor.png)
+![lightline.vim - PaperColor](../../wiki/image/PaperColor.png)
 
 ### seoul256
 
-![lightline.vim - seoul256](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/seoul256.png)
+![lightline.vim - seoul256](../../wiki/image/seoul256.png)
 
 ### one
 
-![lightline.vim - one](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/one.png)
+![lightline.vim - one](../../wiki/image/one.png)
 
 ### landscape
 
-![lightline.vim - landscape](https://raw.githubusercontent.com/wiki/itchyny/lightline.vim/image/landscape.png)
+![lightline.vim - landscape](../../wiki/image/landscape.png)
 
 landscape is my colorscheme, which is a high-contrast cterm-supported colorscheme, available at https://github.com/itchyny/landscape.vim
 
 ### simpleblack
 
-![lightline.vim - simpleblack](https://user-images.githubusercontent.com/2293178/67733484-da28ca00-f9d4-11e9-904f-1636b6b38d81.png)
+![lightline.vim - simpleblack](../../wiki/image/simpleblack.png)
 
 Based on a colorscheme called [simpleblack](https://github.com/lucasprag/simpleblack)
 
+
+For screenshots of all available colorshemes, see [this file](colorscheme.md).
 
 ## Why yet another clone of powerline?
 + [vim-powerline](https://github.com/Lokaltog/vim-powerline) is a nice plugin, but deprecated.

--- a/colorscheme.md
+++ b/colorscheme.md
@@ -1,0 +1,109 @@
+# Available Colorschemes
+
+### 16color
+
+![lightline.vim - 16color](../../wiki/image/16color.png)
+
+### OldHope
+
+![lightline.vim - OldHope](../../wiki/image/OldHope.png)
+
+### PaperColor dark
+
+![lightline.vim - PaperColor dark](../../wiki/image/PaperColor_dark.png)
+
+### PaperColor light
+
+![lightline.vim - PaperColor light](../../wiki/image/PaperColor.png)
+
+### Tomorrow
+
+![lightline.vim - Tomorrow](../../wiki/image/Tomorrow.png)
+
+### Tomorrow Night
+
+![lightline.vim - Tomorrow Night](../../wiki/image/Tomorrow_Night.png)
+
+### Tomorrow Night Blue
+
+![lightline.vim - Tomorrow Night Blue](../../wiki/image/Tomorrow_Night_Blue.png)
+
+### Tomorrow Night Bright
+
+![lightline.vim - Tomorrow Night Bright](../../wiki/image/Tomorrow_Night_Bright.png)
+
+### Tomorrow Night Eighties
+
+![lightline.vim - Tomorrow Night Eighties](../../wiki/image/Tomorrow_Night_Eighties.png)
+
+### ayu_mirage
+
+![lightline.vim - ayu mirage](../../wiki/image/ayu_mirage.png)
+
+### darcula
+
+![lightline.vim - darcula](../../wiki/image/darcula.png)
+
+### deus
+
+![lightline.vim - deus](../../wiki/image/deus.png)
+
+### jellybeans
+
+![lightline.vim - jellybeans](../../wiki/image/jellybeans.png)
+
+### landscape
+
+![lightline.vim - landscape](../../wiki/image/landscape.png)
+
+### materia
+
+![lightline.vim - materia](../../wiki/image/materia.png)
+
+### material
+
+![lightline.vim - material](../../wiki/image/material.png)
+
+### molokai
+
+![lightline.vim - molokai](../../wiki/image/molokai.png)
+
+### nord
+
+![lightline.vim - nord](../../wiki/image/nord.png)
+
+### one
+
+![lightline.vim - one](../../wiki/image/one.png)
+
+### powerline (default)
+
+![lightline.vim - powerline](../../wiki/image/powerline.png)
+
+### powerlineish
+
+![lightline.vim - powerlineish](../../wiki/image/powerlineish.png)
+
+### selenized dark
+
+![lightline.vim - selenized dark](../../wiki/image/selenized_dark.png)
+
+### seoul256
+
+![lightline.vim - seoul256](../../wiki/image/seoul256.png)
+
+### simpleblack
+
+![lightline.vim - simpleblack](../../wiki/image/simpleblack.png)
+
+### solarized
+
+![lightline.vim - solarized](../../wiki/image/solarized.png)
+
+### srcery drk
+
+![lightline.vim - srcery drk](../../wiki/image/srcery_drk.png)
+
+### wombat
+
+![lightline.vim - wombat](../../wiki/image/wombat.png)


### PR DESCRIPTION
Currently, there are some screenshots of available colorschemes at the beginning of the README.

These changes add a new `.md` file linked to from the README with a comprehensive set of screenshots for all available colorschemes, with the image files linked from the project Wiki using relative paths.

I have all of the screenshots in the Wiki of my fork, so feel free to pull that down with `git clone https://github.com/favorable-mutation/lightline.vim.wiki.git` in order to move them over to the actual project's Wiki.