### PR TITLE
Adding ayu_light colorscheme

### DIFF
--- a/autoload/lightline/colorscheme/ayu_light.vim
+++ b/autoload/lightline/colorscheme/ayu_light.vim
@@ -1,0 +1,39 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/ayu_light.vim
+" Author: christalib
+" License: MIT License
+" Last Change: 2020/02/11 13:52:20.
+" =============================================================================
+let s:base0 = [ '#5C6773', 244 ]
+let s:base1 = [ '#5C6773', 247 ]
+let s:base2 = [ '#828C99', 248 ]
+let s:base3 = [ '#5C6773', 252 ]
+let s:base00 = [ '#FFFFFF', 242  ]
+let s:base01 = [ '#FFFFFF', 240 ]
+let s:base02 = [ '#FAFAFA', 238 ]
+let s:base023 = [ '#FAFAFA', 236 ]
+let s:base03 = [ '#E6B673c', 235 ]
+let s:yellow = [ '#E6B673c', 180 ]
+let s:orange = [ '#FF7733', 173 ]
+let s:red = [ '#f07178', 203 ]
+let s:magenta = [ '#A37ACC', 216 ]
+let s:blue = [ '#59c2ff', 117 ]
+let s:cyan = s:blue
+let s:green = [ '#86B300', 119 ]
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base02, s:blue ], [ s:base3, s:base01 ] ]
+let s:p.normal.middle = [ [ s:base2, s:base02 ] ]
+let s:p.normal.right = [ [ s:base02, s:base0 ], [ s:base1, s:base01 ] ]
+let s:p.inactive.left =  [ [ s:base1, s:base01 ], [ s:base3, s:base01 ] ]
+let s:p.inactive.middle = [ [ s:base1, s:base023 ] ]
+let s:p.inactive.right = [ [ s:base1, s:base01 ], [ s:base2, s:base02 ] ]
+let s:p.insert.left = [ [ s:base02, s:green ], [ s:base3, s:base01 ] ]
+let s:p.replace.left = [ [ s:base023, s:red ], [ s:base3, s:base01 ] ]
+let s:p.visual.left = [ [ s:base02, s:magenta ], [ s:base3, s:base01 ] ]
+let s:p.tabline.tabsel = [ [ s:base02, s:base03 ] ]
+let s:p.tabline.left = [ [ s:base3, s:base00 ] ]
+let s:p.tabline.middle = [ [ s:base2, s:base02 ] ]
+let s:p.tabline.right = [ [ s:base2, s:base00 ] ]
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base023, s:yellow ] ]
+let g:lightline#colorscheme#ayu_light#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
Hi! 

I was noticing [Ayu](https://github.com/ayu-theme)  was ported but only the Mirage version of the colorscheme. So I took some time to port the light version to lightline in case you need to use the light version of the colorscheme as well. I followed the theme's [color table](https://github.com/ayu-theme/ayu-vim/blob/master/colors/ayu.vim)

It is the first time I open a PR for this project, let me know if you need anything more from me about this work :) 

I have also joined some screenshots to give you an idea of what it looked like. 

![Screenshot from 2020-02-11 16-12-29](https://user-images.githubusercontent.com/3540752/74249910-2bda3380-4cea-11ea-87f2-96e6ebf242d4.png)
![Screenshot from 2020-02-11 16-12-50](https://user-images.githubusercontent.com/3540752/74249912-2c72ca00-4cea-11ea-9d90-596781a8dd58.png)
![Screenshot from 2020-02-11 16-13-12](https://user-images.githubusercontent.com/3540752/74249915-2c72ca00-4cea-11ea-8931-f416f1a45423.png)
![Screenshot from 2020-02-11 16-20-23](https://user-images.githubusercontent.com/3540752/74250115-73f95600-4cea-11ea-898e-a2a08ca271e1.png)



