### PR TITLE
Tabline disappears in vim-lsp popup

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -54,6 +54,9 @@ function! lightline#enable() abort
 endfunction
 
 function! lightline#disable() abort
+  if !s:lightline.enable.tabline && &tabline != s:_tabline
+      let s:_tabline = &tabline  " change tabline after lightline#init
+  endif
   let [&statusline, &tabline] = [get(s:, '_statusline', ''), get(s:, '_tabline', '')]
   for t in range(1, tabpagenr('$'))
     for n in range(1, tabpagewinnr(t, '$'))


### PR DESCRIPTION
(Google translation)
vim-lsp has lightline [temporarily disable processing](https://github.com/prabirshrestha/vim-lsp/blob/6e78f35aad2969285fd4e776a44035bd730f3389/autoload/lsp/ui/vim/output.vim#L148) Included,
As a result, the content of [tabline] was lost.

After temporarily disabling, when  enable it obtained by `lightline # init`
Set `s: _tabline` to` & tabline`, but
If `& tabline` is changed after` lightline # init`, it will not be restored.
(Such as when another plugin makes a change)

Should `& tabline` not be changed when` s: lightline.enable.tabline` is disabled,
If `& tabline` and` s: _tabline` are different at the timing of `lightline # disable`, whether to set` s: _tabline` again,
I was worried about which solution was better, but I chose the one with less correction.
Please review.

---

vim-lspにはlightlineを[一時的に無効にする処理](https://github.com/prabirshrestha/vim-lsp/blob/6e78f35aad2969285fd4e776a44035bd730f3389/autoload/lsp/ui/vim/output.vim#L148)が含まれていますが、
この影響で、[tabline]の内容が消えてしまう現象がありました。

一時的に無効にした後、有効にする際に`lightline#init`で取得した
`s:_tabline`を`&tabline`に設定しますが、
`lightline#init`後に`&tabline`が変更されていた場合に元通りの設定になりません。
（他のプラグインが変更を行った場合など）

`s:lightline.enable.tabline`が無効の場合に`&tabline`には変更を行わないようにするべきか、
`lightline#disable`のタイミングで`&tabline`と`s:_tabline`が異なっていれば再度`s:_tabline`を設定し直すべきか、
どちらの対応が良いのか悩みましたが、修正量の少ない方を選んでみました。
レビューお願いします。

（日本語ですみません。。。）
