### PR TITLE
Add minimal color scheme

### DIFF
--- a/autoload/lightline/colorscheme/minimal.vim
+++ b/autoload/lightline/colorscheme/minimal.vim
@@ -1,0 +1,39 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/minimal.vim
+" Author: juacq97
+" License: MIT
+" Last Change: 2020/04/24 20:27:51
+" =============================================================================
+
+" [ [ fg, bg ] ] 
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+
+let s:bg = ["#2E3440", "NONE"] 
+let s:fg = ["#2e3440", 7]
+let s:fgn = ["#000000", 0]
+let s:bn = ["#00ffff", 51]
+let s:bi = ["#00ff00", 82]
+let s:br = ["#ff0000", 11]
+let s:bv = ["#ffff00", 9]
+
+
+let s:p.normal.middle = [ [ s:fg, s:bg ] ]
+let s:p.normal.right = [ [ s:fg, s:bg ], [ s:fg, s:bg ] ]
+let s:p.normal.warning = [ [ s:fg, s:bv ] ]
+let s:p.normal.error = [ [ s:fg, s:bv ] ]
+
+let s:p.inactive.left =  [ [ s:fgn, s:bg ], [ s:fg, s:bg ] ]
+let s:p.inactive.middle = [ [ s:fg, s:bg ] ]
+let s:p.inactive.right = [ [ s:fg, s:bg ], [ s:fg, s:bg ] ]
+
+let s:p.normal.left = [ [ s:bn, s:bg, 'bold' ], [ s:fg, s:bg ] ]
+let s:p.insert.left = [ [ s:bi, s:bg, 'bold' ], [ s:fg, s:bg ] ]
+let s:p.replace.left = [ [ s:br, s:bg, 'bold' ], [ s:fg, s:bg ] ]
+let s:p.visual.left = [ [ s:bv, s:bg, 'bold' ], [ s:fg, s:bg ] ]
+
+let s:p.tabline.left = [ [ s:fg, s:bg ] ]
+let s:p.tabline.middle = [ [ s:fg, s:bg ] ]
+let s:p.tabline.right = [ [ s:fg, s:bg ] ]
+let s:p.tabline.tabsel = [ [ s:bg, s:fg ] ]
+
+let g:lightline#colorscheme#minimal#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
I wrote this colorscheme, uses a transparent background and colored foreground for the active mode. Works with any terminal colorscheme.

![mutheme](https://user-images.githubusercontent.com/7623047/80233341-91646d80-8613-11ea-8244-cf3339b60ff3.png)
