### PR TITLE
Add support for terminal colors for selenized colorschemes

### DIFF
--- a/autoload/lightline/colorscheme/selenized_black.vim
+++ b/autoload/lightline/colorscheme/selenized_black.vim
@@ -6,21 +6,21 @@
 " =============================================================================
 
 " https://github.com/jan-warchol/selenized/blob/master/the-values.md#selenized-black
-let s:bg_1      = '#252525'
-let s:bg_2      = '#3b3b3b'
-let s:dim_0     = '#777777'
-let s:red       = '#ed4a46'
-let s:green     = '#70b433'
-let s:yellow    = '#dbb32d'
-let s:blue      = '#368aeb'
-let s:magenta   = '#eb6eb7'
-let s:cyan      = '#3fc5b7'
-let s:brred     = '#ff5e56'
-let s:brgreen   = '#83c746'
-let s:bryellow  = '#efc541'
-let s:brblue    = '#4f9cfe'
-let s:brmagenta = '#ff81ca'
-let s:brcyan    = '#56d8c9'
+let s:bg_1      = ['#252525', 0]
+let s:bg_2      = ['#3b3b3b', 8]
+let s:dim_0     = ['#777777', 7]
+let s:red       = ['#ed4a46', 1]
+let s:green     = ['#70b433', 2]
+let s:yellow    = ['#dbb32d', 3]
+let s:blue      = ['#368aeb', 4]
+let s:magenta   = ['#eb6eb7', 5]
+let s:cyan      = ['#3fc5b7', 6]
+let s:brred     = ['#ff5e56', 9]
+let s:brgreen   = ['#83c746', 10]
+let s:bryellow  = ['#efc541', 11]
+let s:brblue    = ['#4f9cfe', 12]
+let s:brmagenta = ['#ff81ca', 13]
+let s:brcyan    = ['#56d8c9', 14]
 
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
@@ -46,4 +46,4 @@ let s:p.tabline.right = [[ s:bg_1, s:red ]]
 let s:p.tabline.left = [[ s:cyan, s:bg_2 ]]
 let s:p.tabline.tabsel = [[ s:bg_1, s:blue ]]
 
-let g:lightline#colorscheme#selenized_black#palette = lightline#colorscheme#fill(s:p)
+let g:lightline#colorscheme#selenized_black#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/selenized_dark.vim
+++ b/autoload/lightline/colorscheme/selenized_dark.vim
@@ -6,21 +6,21 @@
 " =============================================================================
 
 " https://github.com/jan-warchol/selenized/blob/master/the-values.md#selenized-dark
-let s:bg_1      = '#184956'
-let s:bg_2      = '#2d5b69'
-let s:dim_0     = '#72898f'
-let s:red       = '#fa5750'
-let s:green     = '#75b938'
-let s:yellow    = '#dbb32d'
-let s:blue      = '#4695f7'
-let s:magenta   = '#f275be'
-let s:cyan      = '#41c7b9'
-let s:brred     = '#ff665c'
-let s:brgreen   = '#84c747'
-let s:bryellow  = '#ebc13d'
-let s:brblue    = '#58a3ff'
-let s:brmagenta = '#ff84cd'
-let s:brcyan    = '#53d6c7'
+let s:bg_1      = ['#184956', 0]
+let s:bg_2      = ['#2d5b69', 8]
+let s:dim_0     = ['#72898f', 7]
+let s:red       = ['#fa5750', 1]
+let s:green     = ['#75b938', 2]
+let s:yellow    = ['#dbb32d', 3]
+let s:blue      = ['#4695f7', 4]
+let s:magenta   = ['#f275be', 5]
+let s:cyan      = ['#41c7b9', 6]
+let s:brred     = ['#ff665c', 9]
+let s:brgreen   = ['#84c747', 10]
+let s:bryellow  = ['#ebc13d', 11]
+let s:brblue    = ['#58a3ff', 12]
+let s:brmagenta = ['#ff84cd', 13]
+let s:brcyan    = ['#53d6c7', 14]
 
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
@@ -46,4 +46,4 @@ let s:p.tabline.right = [[ s:bg_1, s:red ]]
 let s:p.tabline.left = [[ s:cyan, s:bg_2 ]]
 let s:p.tabline.tabsel = [[ s:bg_1, s:blue ]]
 
-let g:lightline#colorscheme#selenized_dark#palette = lightline#colorscheme#fill(s:p)
+let g:lightline#colorscheme#selenized_dark#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/selenized_light.vim
+++ b/autoload/lightline/colorscheme/selenized_light.vim
@@ -6,21 +6,21 @@
 " =============================================================================
 
 " https://github.com/jan-warchol/selenized/blob/master/the-values.md#selenized-light
-let s:bg_1      = '#ece3cc'
-let s:bg_2      = '#d5cdb6'
-let s:dim_0     = '#909995'
-let s:red       = '#d2212d'
-let s:green     = '#489100'
-let s:yellow    = '#ad8900'
-let s:blue      = '#0072d4'
-let s:magenta   = '#ca4898'
-let s:cyan      = '#009c8f'
-let s:brred     = '#cc1729'
-let s:brgreen   = '#428b00'
-let s:bryellow  = '#a78300'
-let s:brblue    = '#006dce'
-let s:brmagenta = '#c44392'
-let s:brcyan    = '#00978a'
+let s:bg_1      = ['#ece3cc', 0]
+let s:bg_2      = ['#d5cdb6', 8]
+let s:dim_0     = ['#909995', 7]
+let s:red       = ['#d2212d', 1]
+let s:green     = ['#489100', 2]
+let s:yellow    = ['#ad8900', 3]
+let s:blue      = ['#0072d4', 4]
+let s:magenta   = ['#ca4898', 5]
+let s:cyan      = ['#009c8f', 6]
+let s:brred     = ['#cc1729', 9]
+let s:brgreen   = ['#428b00', 10]
+let s:bryellow  = ['#a78300', 11]
+let s:brblue    = ['#006dce', 12]
+let s:brmagenta = ['#c44392', 13]
+let s:brcyan    = ['#00978a', 14]
 
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
@@ -46,4 +46,4 @@ let s:p.tabline.right = [[ s:bg_1, s:red ]]
 let s:p.tabline.left = [[ s:cyan, s:bg_2 ]]
 let s:p.tabline.tabsel = [[ s:bg_1, s:blue ]]
 
-let g:lightline#colorscheme#selenized_light#palette = lightline#colorscheme#fill(s:p)
+let g:lightline#colorscheme#selenized_light#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/selenized_white.vim
+++ b/autoload/lightline/colorscheme/selenized_white.vim
@@ -6,21 +6,21 @@
 " =============================================================================
 
 " https://github.com/jan-warchol/selenized/blob/master/the-values.md#selenized-white
-let s:bg_1      = '#ebebeb'
-let s:bg_2      = '#cdcdcd'
-let s:dim_0     = '#878787'
-let s:red       = '#d6000c'
-let s:green     = '#1d9700'
-let s:yellow    = '#c49700'
-let s:blue      = '#0064e4'
-let s:magenta   = '#dd0f9d'
-let s:cyan      = '#00ad9c'
-let s:brred     = '#bf0000'
-let s:brgreen   = '#008400'
-let s:bryellow  = '#af8500'
-let s:brblue    = '#0054cf'
-let s:brmagenta = '#c7008b'
-let s:brcyan    = '#009a8a'
+let s:bg_1      = [ '#ebebeb', 0]
+let s:bg_2      = [ '#cdcdcd', 8]
+let s:dim_0     = [ '#878787', 7]
+let s:red       = [ '#d6000c', 1]
+let s:green     = [ '#1d9700', 2]
+let s:yellow    = [ '#c49700', 3]
+let s:blue      = [ '#0064e4', 4]
+let s:magenta   = [ '#dd0f9d', 5]
+let s:cyan      = [ '#00ad9c', 6]
+let s:brred     = [ '#bf0000', 9]
+let s:brgreen   = [ '#008400', 10]
+let s:bryellow  = [ '#af8500', 11]
+let s:brblue    = [ '#0054cf', 12]
+let s:brmagenta = [ '#c7008b', 13]
+let s:brcyan    = [ '#009a8a', 14]
 
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
@@ -46,4 +46,4 @@ let s:p.tabline.right = [[ s:bg_1, s:red ]]
 let s:p.tabline.left = [[ s:cyan, s:bg_2 ]]
 let s:p.tabline.tabsel = [[ s:bg_1, s:blue ]]
 
-let g:lightline#colorscheme#selenized_white#palette = lightline#colorscheme#fill(s:p)
+let g:lightline#colorscheme#selenized_white#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
As the selenized documentation notes, setting the proper terminal
palette is the preferred method of using selenized in terminal. This
patch enables that mode using airline's built-in flatten method, while
keeps the true color definitions for gui vim.