### PR TITLE
improve tabline colors for colorscheme jellybeans

### DIFF
--- a/autoload/lightline/colorscheme/jellybeans.vim
+++ b/autoload/lightline/colorscheme/jellybeans.vim
@@ -30,10 +30,10 @@ let s:p.replace.left = [ [ s:base02, s:red ], [ s:base3, s:base01 ] ]
 let s:p.visual.left = [ [ s:base02, s:magenta ], [ s:base3, s:base01 ] ]
 let s:p.normal.middle = [ [ s:base0, s:base02 ] ]
 let s:p.inactive.middle = [ [ s:base00, s:base02 ] ]
-let s:p.tabline.left = [ [ s:base3, s:base00 ] ]
-let s:p.tabline.tabsel = [ [ s:base3, s:base02 ] ]
-let s:p.tabline.middle = [ [ s:base01, s:base1 ] ]
-let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.tabline.left = copy(s:p.normal.middle)
+let s:p.tabline.tabsel = [ [ s:base3, s:base00 ] ]
+let s:p.tabline.middle = copy(s:p.normal.middle)
+let s:p.tabline.right = copy(s:p.tabline.middle)
 let s:p.normal.error = [ [ s:red, s:base02 ] ]
 let s:p.normal.warning = [ [ s:yellow, s:base01 ] ]
 


### PR DESCRIPTION
Tabline colors in original colorscheme jellybeans with dark background:

<img width="816" alt="tabline_jellybeans_original" src="https://user-images.githubusercontent.com/56977205/86976609-b440f100-c12f-11ea-9436-421fb77516bf.png">

(Possibly improved) tabline colors in updated colorscheme jellybeans with dark background:

<img width="816" alt="tabline_jellybeans_updated" src="https://user-images.githubusercontent.com/56977205/86976700-e3576280-c12f-11ea-9f5b-bcdc3c3f80d3.png">
