### PR TITLE
Use column instead of virtual column in lineinfo

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -110,7 +110,7 @@ let s:_lightline = {
       \     'paste': '%{&paste?"PASTE":""}', 'readonly': '%R', 'charvalue': '%b', 'charvaluehex': '%B',
       \     'spell': '%{&spell?&spelllang:""}', 'fileencoding': '%{&fenc!=#""?&fenc:&enc}', 'fileformat': '%{&ff}',
       \     'filetype': '%{&ft!=#""?&ft:"no ft"}', 'percent': '%3p%%', 'percentwin': '%P',
-      \     'lineinfo': '%3l:%-2v', 'line': '%l', 'column': '%c', 'close': '%999X X ', 'winnr': '%{winnr()}'
+      \     'lineinfo': '%3l:%-2c', 'line': '%l', 'column': '%c', 'close': '%999X X ', 'winnr': '%{winnr()}'
       \   },
       \   'component_visible_condition': {
       \     'modified': '&modified||!&modifiable', 'readonly': '&readonly', 'paste': '&paste', 'spell': '&spell'

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -107,7 +107,7 @@ OPTIONS						*lightline-option*
 		    \ 'percent': '%3p%%',
 		    \ 'percentwin': '%P',
 		    \ 'spell': '%{&spell?&spelllang:""}',
-		    \ 'lineinfo': '%3l:%-2v',
+		    \ 'lineinfo': '%3l:%-2c',
 		    \ 'line': '%l',
 		    \ 'column': '%c',
 		    \ 'close': '%999X X ',
@@ -305,7 +305,7 @@ nice.
 >
 	let g:lightline = {
 		\ 'component': {
-		\   'lineinfo': ' %3l:%-2v',
+		\   'lineinfo': ' %3l:%-2c',
 		\ },
 		\ 'component_function': {
 		\   'readonly': 'LightlineReadonly',
@@ -330,7 +330,7 @@ look nice.
 >
 	let g:lightline = {
 		\ 'component': {
-		\   'lineinfo': '⭡ %3l:%-2v',
+		\   'lineinfo': '⭡ %3l:%-2c',
 		\ },
 		\ 'component_function': {
 		\   'readonly': 'LightlineReadonly',


### PR DESCRIPTION
i.e. when 'wrap' is set 'showbreak' characters gets counted in in column position.
This seems to be like a more common use, better default.