### PR TITLE
Fix foreground colors in selenized colorschemes

### DIFF
--- a/autoload/lightline/colorscheme/selenized_black.vim
+++ b/autoload/lightline/colorscheme/selenized_black.vim
@@ -26,7 +26,7 @@ let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': 
 
 let s:p.normal.right = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
 let s:p.normal.left = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ]]
-let s:p.normal.middle = [[ s:bg_1, s:bg_1 ]]
+let s:p.normal.middle = [[ s:dim_0, s:bg_1 ]]
 let s:p.normal.error = [[ s:bg_1, s:red ]]
 let s:p.normal.warning = [[ s:bg_1, s:yellow ]]
 

--- a/autoload/lightline/colorscheme/selenized_dark.vim
+++ b/autoload/lightline/colorscheme/selenized_dark.vim
@@ -26,7 +26,7 @@ let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': 
 
 let s:p.normal.right = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
 let s:p.normal.left = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ]]
-let s:p.normal.middle = [[ s:bg_1, s:bg_1 ]]
+let s:p.normal.middle = [[ s:dim_0, s:bg_1 ]]
 let s:p.normal.error = [[ s:bg_1, s:red ]]
 let s:p.normal.warning = [[ s:bg_1, s:yellow ]]
 

--- a/autoload/lightline/colorscheme/selenized_light.vim
+++ b/autoload/lightline/colorscheme/selenized_light.vim
@@ -26,7 +26,7 @@ let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': 
 
 let s:p.normal.right = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
 let s:p.normal.left = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ]]
-let s:p.normal.middle = [[ s:bg_1, s:bg_1 ]]
+let s:p.normal.middle = [[ s:dim_0, s:bg_1 ]]
 let s:p.normal.error = [[ s:bg_1, s:red ]]
 let s:p.normal.warning = [[ s:bg_1, s:yellow ]]
 

--- a/autoload/lightline/colorscheme/selenized_white.vim
+++ b/autoload/lightline/colorscheme/selenized_white.vim
@@ -26,7 +26,7 @@ let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': 
 
 let s:p.normal.right = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
 let s:p.normal.left = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ]]
-let s:p.normal.middle = [[ s:bg_1, s:bg_1 ]]
+let s:p.normal.middle = [[ s:dim_0, s:bg_1 ]]
 let s:p.normal.error = [[ s:bg_1, s:red ]]
 let s:p.normal.warning = [[ s:bg_1, s:yellow ]]
 


### PR DESCRIPTION
Fix #504 

This pull request changes the foreground color of normal.middle from bg_1 to dim_0 (foreground color of normal.right).

before: normal.middle is invisible.
![normal-middle-invisible](https://user-images.githubusercontent.com/11911089/92112167-5a576180-ee28-11ea-8be2-f7cd56dc3376.png)

after: normal.middle is visible.
![normal-middle-visible](https://user-images.githubusercontent.com/11911089/92112197-6511f680-ee28-11ea-8e24-bb7ffc632f87.png)
