### PR TITLE
Make selenized theme more similar to solazied

### DIFF
--- a/autoload/lightline/colorscheme/selenized_light.vim
+++ b/autoload/lightline/colorscheme/selenized_light.vim
@@ -6,8 +6,10 @@
 " =============================================================================
 
 " https://github.com/jan-warchol/selenized/blob/master/the-values.md#selenized-light
-let s:bg_1      = ['#ece3cc', 0]
-let s:bg_2      = ['#d5cdb6', 8]
+" https://github.com/jan-warchol/selenized/blob/master/manual-installation.md
+let s:fg_0      = ['#53676d', 0]
+let s:bg_1      = ['#e9e4d0', 0]
+let s:bg_2      = ['#cfcebe', 8]
 let s:dim_0     = ['#909995', 7]
 let s:red       = ['#d2212d', 1]
 let s:green     = ['#489100', 2]
@@ -24,26 +26,26 @@ let s:brcyan    = ['#00978a', 14]
 
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
-let s:p.normal.right = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
-let s:p.normal.left = [[ s:bg_1, s:blue ], [ s:cyan, s:bg_2 ]]
+let s:p.normal.right = [[ s:bg_1, s:blue ], [ s:bg_1, s:dim_0 ], [ s:fg_0, s:bg_1 ]]
+let s:p.normal.left = [[ s:bg_1, s:blue ], [ s:bg_1, s:dim_0 ]]
 let s:p.normal.middle = [[ s:dim_0, s:bg_1 ]]
 let s:p.normal.error = [[ s:bg_1, s:red ]]
 let s:p.normal.warning = [[ s:bg_1, s:yellow ]]
 
-let s:p.insert.right = [[ s:bg_1, s:green ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
-let s:p.insert.left = [[ s:bg_1, s:green ], [ s:cyan, s:bg_2 ]]
+let s:p.insert.right = [[ s:bg_1, s:green ], [ s:bg_1, s:dim_0 ], [ s:fg_0, s:bg_1 ]]
+let s:p.insert.left = [[ s:bg_1, s:green ], [ s:bg_1, s:dim_0 ]]
 
-let s:p.visual.right = [[ s:bg_1, s:magenta ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
-let s:p.visual.left = [[ s:bg_1, s:magenta ], [ s:cyan, s:bg_2 ]]
+let s:p.visual.right = [[ s:bg_1, s:magenta ], [ s:bg_1, s:dim_0 ], [ s:fg_0, s:bg_1 ]]
+let s:p.visual.left = [[ s:bg_1, s:magenta ], [ s:bg_1, s:dim_0 ]]
 
-let s:p.inactive.left = [[ s:brblue, s:bg_2 ], [ s:cyan, s:bg_2 ]]
-let s:p.inactive.right = [[ s:brblue, s:bg_2 ], [ s:cyan, s:bg_2 ]]
+let s:p.inactive.right = [[ s:bg_1, s:dim_0 ], [ s:fg_0, s:bg_1 ]]
+let s:p.inactive.left = [[ s:dim_0, s:bg_1 ], [ s:bg_1, s:dim_0 ]]
 
-let s:p.replace.right = [[ s:bg_1, s:red ], [ s:cyan, s:bg_2 ], [ s:dim_0, s:bg_1 ]]
-let s:p.replace.left = [[ s:bg_1, s:red ], [ s:cyan, s:bg_2 ]]
+let s:p.replace.right = [[ s:bg_1, s:red ], [ s:bg_1, s:dim_0 ], [ s:fg_0, s:bg_1 ]]
+let s:p.replace.left = [[ s:bg_1, s:red ], [ s:bg_1, s:dim_0 ]]
 
 let s:p.tabline.right = [[ s:bg_1, s:red ]]
-let s:p.tabline.left = [[ s:cyan, s:bg_2 ]]
+let s:p.tabline.left = [[ s:bg_1, s:dim_0 ]]
 let s:p.tabline.tabsel = [[ s:bg_1, s:blue ]]
 
 let g:lightline#colorscheme#selenized_light#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
closes #524 

I just have a question, what number can i set `let s:fg_0      = ['#53676d', 0]`? In the selenized theme, the foreground and background colors aren't one of the 15 terminal colors.

This is a work in progress, i will update the other themes to follow the same style.

this is how it looks:
![selenized](https://user-images.githubusercontent.com/14265358/97647996-66c7f700-1a32-11eb-9eb8-c0816f9b8a52.png)

the only difference between the solarized theme (apart from the colors) is that the right most part follows the mode indicator color, for me it looks nice.