### PR TITLE
Skip floating windows in nvim

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -32,6 +32,12 @@ if exists('*win_gettype')
   endfunction
 else
   function! s:skip() abort
+    if has('nvim')
+      if nvim_win_get_config(nvim_get_current_win()).relative != ''
+        return 1
+      endif
+    endif
+
     return &buftype ==# 'popup'
   endfunction
 endif


### PR DESCRIPTION
Plugins like [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim) make use of NeoVim's floating windows but lightline doesn't skip those so status line becomes disabled the first time such window appears.

Source: [This neovim issue](https://github.com/neovim/neovim/issues/12389), `:help api-window`