### PR TITLE
Add apprentice colorscheme

### DIFF
--- a/autoload/lightline/colorscheme/apprentice.vim
+++ b/autoload/lightline/colorscheme/apprentice.vim
@@ -1,0 +1,46 @@
+" =============================================================================
+" Filename: autoload/lightline/colorscheme/apprentice.vim
+" Author: pt307 (based on work by romainl)
+" License: MIT License
+" Last Change: 2021/03/02 18:25:22.
+" =============================================================================
+
+" For the Apprentice colorscheme <https://github.com/romainl/Apprentice>
+
+let s:almost_black = [ '#1c1c1c', 234 ]
+let s:darker_grey  = [ '#262626', 235 ]
+let s:medium_grey  = [ '#585858', 240 ]
+let s:lighter_grey = [ '#bcbcbc', 250 ]
+let s:green        = [ '#5f875f',  65 ]
+let s:red          = [ '#af5f5f', 131 ]
+let s:orange       = [ '#ff8700', 208 ]
+let s:ocre         = [ '#87875f', 101 ]
+let s:yellow       = [ '#ffffaf', 229 ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+
+let s:p.normal.left     = [ [ s:darker_grey, s:ocre ], [ s:darker_grey, s:medium_grey ] ]
+let s:p.normal.middle   = [ [ s:lighter_grey, s:darker_grey ] ]
+let s:p.normal.right    = [ [ s:darker_grey, s:ocre ], [ s:darker_grey, s:medium_grey ] ]
+let s:p.normal.warning  = [ [ s:almost_black, s:orange ] ]
+let s:p.normal.error    = [ [ s:almost_black, s:red ] ]
+
+let s:p.inactive.left   = [ [ s:darker_grey, s:medium_grey ] ]
+let s:p.inactive.middle = [ [ s:medium_grey, s:darker_grey ] ]
+let s:p.inactive.right  = [ [ s:darker_grey, s:medium_grey ] ]
+
+let s:p.insert.left     = [ [ s:darker_grey, s:green ], [ s:darker_grey, s:medium_grey ] ]
+let s:p.insert.right    = [ [ s:darker_grey, s:green ], [ s:darker_grey, s:medium_grey ] ]
+
+let s:p.replace.left    = [ [ s:darker_grey, s:red ], [ s:darker_grey, s:medium_grey ] ]
+let s:p.replace.right   = [ [ s:darker_grey, s:red ], [ s:darker_grey, s:medium_grey ] ]
+
+let s:p.visual.left     = [ [ s:darker_grey, s:yellow ], [ s:darker_grey, s:medium_grey ] ]
+let s:p.visual.right    = [ [ s:darker_grey, s:yellow ], [ s:darker_grey, s:medium_grey ] ]
+
+let s:p.tabline.left    = [ [ s:darker_grey, s:medium_grey ] ]
+let s:p.tabline.middle  = [ [ s:lighter_grey, s:darker_grey ] ]
+let s:p.tabline.right   = [ [ s:darker_grey, s:medium_grey ] ]
+let s:p.tabline.tabsel  = [ [ s:darker_grey, s:ocre ] ]
+
+let g:lightline#colorscheme#apprentice#palette = lightline#colorscheme#flatten(s:p)

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -232,8 +232,8 @@ OPTIONS						*lightline-option*
 		Tomorrow, Tomorrow_Night, Tomorrow_Night_Blue,
 		Tomorrow_Night_Bright, Tomorrow_Night_Eighties, PaperColor,
 		landscape, one, materia, material, OldHope, nord, deus,
-		simpleblack, srcery_drk, ayu_mirage, ayu_light, ayu_dark and
-		16color are available.
+		simpleblack, srcery_drk, ayu_mirage, ayu_light, ayu_dark,
+		apprentice and 16color are available.
 		The default value is:
 >
 		let g:lightline.colorscheme = 'default'


### PR DESCRIPTION
<img width="840" alt="apprentice-lightline" src="https://user-images.githubusercontent.com/6432737/109700717-0c7aa680-7b8a-11eb-8c83-56196fa12ab3.png">

This is for the [Apprentice](https://github.com/romainl/Apprentice) colorscheme. The author of that keeps a [lightline colorscheme](https://github.com/romainl/Apprentice/blob/fancylines-and-neovim/autoload/lightline/colorscheme/apprentice.vim) in a separate [branch](https://github.com/romainl/Apprentice/tree/fancylines-and-neovim) and does not want to support or maintain it. He is happy for me to submit the colorscheme for inclusion in lightline.vim and will point Apprentice users towards it from the projects README, as per the discussion in this [pull request](https://github.com/romainl/Apprentice/pull/60).

I've refactored the colorscheme file to tidy it up and make it easier to maintain, but the color choices and appearance remain the same as the original. I note in your documentation you say that new colorschemes should default _Normal_ mode to cyan, but this colorscheme has long used a different color for that (the same color used by Apprentice for the Vim statusline, as seen in the repositories' screenshots) so hopefully an exception can be made.

The variable names chosen come from the [color list](https://github.com/romainl/Apprentice/blob/e6da880abc774ab1497fd55da0d220c49223798a/colors/apprentice.erb#L65) used to generate the Vim colorscheme to make it easier for users to customize the theme if they choose to.