### PR TITLE
Replace column number with virtual column number

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -110,7 +110,7 @@ let s:_lightline = {
       \     'paste': '%{&paste?"PASTE":""}', 'readonly': '%R', 'charvalue': '%b', 'charvaluehex': '%B',
       \     'spell': '%{&spell?&spelllang:""}', 'fileencoding': '%{&fenc!=#""?&fenc:&enc}', 'fileformat': '%{&ff}',
       \     'filetype': '%{&ft!=#""?&ft:"no ft"}', 'percent': '%3p%%', 'percentwin': '%P',
-      \     'lineinfo': '%3l:%-2c', 'line': '%l', 'column': '%c', 'close': '%999X X ', 'winnr': '%{winnr()}'
+      \     'lineinfo': '%3l:%-2v', 'line': '%l', 'column': '%v', 'close': '%999X X ', 'winnr': '%{winnr()}'
       \   },
       \   'component_visible_condition': {
       \     'modified': '&modified||!&modifiable', 'readonly': '&readonly', 'paste': '&paste', 'spell': '&spell'


### PR DESCRIPTION
See [this airline issue](https://github.com/vim-airline/vim-airline/issues/305) which discusses the exact same problem.

Synopsis: `%c` only counts bytes, but with every non-ascii symbol (including umlauts, for example) having more than one byte the "column number" doesn't show what you acutally want to know – the column – but actually the byte position. `%v` is the virtual column which is usually what you want to know.