### PR TITLE
allow matching of full mode

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -211,7 +211,7 @@ function! lightline#palette() abort
 endfunction
 
 function! lightline#mode() abort
-  return get(s:lightline.mode_map, mode(), '')
+  return get(s:lightline.mode_map, mode(1), get(s:lightline.mode_map, mode(), ''))
 endfunction
 
 let s:mode = ''


### PR DESCRIPTION
This allows mode_map to have more specific entries for submodes such as
insert+\<C-X>, but it will fall back on the basic mode if no more
specific match is found.