### PR TITLE
change if x | foo | endif issue with neovim

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -11,9 +11,13 @@ set cpo&vim
 let s:_ = 1 " 1: uninitialized, 2: disabled
 
 function! lightline#update() abort
-  if s:skip() | return | endif
+  if s:skip()
+    return
+  endif
   if s:_
-    if s:_ == 2 | return | endif
+    if s:_ == 2
+      return
+    endif
     call lightline#init()
     call lightline#colorscheme()
   endif


### PR DESCRIPTION
Hi,
ty for awesome lightline, I've used it every day for years.

We seem to hit E171: Missing :endif
when at :s/ in neovim
see https://github.com/neovim/neovim/issues/8796
I am not sure how to fix in neovim, so this is a simple work-around.

thx,
-m