### PR TITLE
add gruvbox dark color scheme

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox_dark.vim
+++ b/autoload/lightline/colorscheme/gruvbox_dark.vim
@@ -41,4 +41,4 @@ let s:p.tabline.middle  = [ [ s:base02, s:base03 ] ]
 let s:p.tabline.right   = [ [ s:base2, s:base02 ] ]
 let s:p.tabline.tabsel  = [ [ s:base3, s:base00 ] ]
 
-let g:lightline#colorscheme#gruvboxdark#palette = lightline#colorscheme#flatten(s:p)
+let g:lightline#colorscheme#gruvbox_dark#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
Integrates [andis-sprinkis/lightline-gruvbox-dark.vim](https://github.com/andis-sprinkis/lightline-gruvbox-dark.vim).

# Preview
![preview of colorscheme](https://raw.githubusercontent.com/andis-sprinkis/lightline-gruvbox-dark.vim/media/preview-dark.png)