### PR TITLE
Respond to light/dark mode changes

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -12,11 +12,9 @@ let s:_ = 1 " 1: uninitialized, 2: disabled
 
 function! lightline#update() abort
   if s:skip() | return | endif
-  if s:_
-    if s:_ == 2 | return | endif
-    call lightline#init()
-    call lightline#colorscheme()
-  endif
+  if s:_ == 2 | return | endif
+  call lightline#init()
+  call lightline#colorscheme()
   if s:lightline.enable.statusline
     let w = winnr()
     let s = winnr('$') == 1 && w > 0 ? [lightline#statusline(0)] : [lightline#statusline(0), lightline#statusline(1)]
@@ -190,6 +188,7 @@ endfunction
 
 function! lightline#colorscheme() abort
   try
+    execute 'runtime autoload/lightline/colorscheme/' . s:lightline.colorscheme . '.vim'
     let s:lightline.palette = g:lightline#colorscheme#{s:lightline.colorscheme}#palette
   catch
     call lightline#error('Could not load colorscheme ' . s:lightline.colorscheme . '.')


### PR DESCRIPTION
Currently if using a colorscheme that offers light and dark mode variants, switching between light and dark mode during a vim session does not affect lightline. The problem appears to be that the colorscheme script does not get sourced again. This pull request aims to fix that, so that users can easily switch between light and dark mode on the fly.