### PR TITLE
add "keymap" component

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -109,11 +109,12 @@ let s:_lightline = {
       \     'absolutepath': '%F', 'relativepath': '%f', 'filename': '%t', 'modified': '%M', 'bufnum': '%n',
       \     'paste': '%{&paste?"PASTE":""}', 'readonly': '%R', 'charvalue': '%b', 'charvaluehex': '%B',
       \     'spell': '%{&spell?&spelllang:""}', 'fileencoding': '%{&fenc!=#""?&fenc:&enc}', 'fileformat': '%{&ff}',
-      \     'filetype': '%{&ft!=#""?&ft:"no ft"}', 'percent': '%3p%%', 'percentwin': '%P',
+      \     'filetype': '%{&ft!=#""?&ft:"no ft"}', 'percent': '%3p%%', 'percentwin': '%P', 'keymap': '%k',
       \     'lineinfo': '%3l:%-2c', 'line': '%l', 'column': '%c', 'close': '%999X X ', 'winnr': '%{winnr()}'
       \   },
       \   'component_visible_condition': {
-      \     'modified': '&modified||!&modifiable', 'readonly': '&readonly', 'paste': '&paste', 'spell': '&spell'
+      \     'modified': '&modified||!&modifiable', 'readonly': '&readonly', 'paste': '&paste', 'spell': '&spell',
+      \     'keymap': '&iminsert'
       \   },
       \   'component_function': {},
       \   'component_function_visible_condition': {},


### PR DESCRIPTION
This adds a default `keymap` component that displays the `%k` keymap statusline info. It toggles nicely in insert mode when `<C-6>` is pressed.