### PR TITLE
fix: Make not to skip floatwin if it is focusable

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -26,7 +26,11 @@ function! lightline#update() abort
   endif
 endfunction
 
-if exists('*win_gettype')
+if exists('*nvim_win_get_config')
+  function! s:skip() abort
+    return !nvim_win_get_config(0).focusable
+  endfunction
+elseif exists('*win_gettype')
   function! s:skip() abort " Vim 8.2.0257 (00f3b4e007), 8.2.0991 (0fe937fd86), 8.2.0996 (40a019f157)
     return win_gettype() ==# 'popup' || win_gettype() ==# 'autocmd'
   endfunction


### PR DESCRIPTION
## Problem

One of the difference between Neovim's floating window and Vim's popup window is focusable.
And since Neovim has global statusline (`laststatus=3`), we can see statusline of floating window.

But currently lightline skipes floating window and the statusline is rendered as inactive.

## Solusion

Make not to skip floatwin if it is focusable.
