### PR TITLE
Do not reset tabline or statusline if they are not used

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -66,7 +66,12 @@ function! lightline#enable() abort
 endfunction
 
 function! lightline#disable() abort
-  let [&statusline, &tabline] = [get(s:, '_statusline', ''), get(s:, '_tabline', '')]
+  if exists('s:_statusline')
+    let &statusline = s:_statusline
+  endif
+  if exists("s:_tabline")
+    let &tabline = s:_tabline
+  endif
   for t in range(1, tabpagenr('$'))
     for n in range(1, tabpagewinnr(t, '$'))
       call settabwinvar(t, n, '&statusline', '')
@@ -172,16 +177,22 @@ function! lightline#init() abort
       break
     endif
   endfor
-  if !exists('s:_statusline')
+  if s:lightline.enable.statusline
     let s:_statusline = &statusline
-  endif
-  if !exists('s:_tabline')
-    let s:_tabline = &tabline
+  else 
+    if exists("s:_statusline")
+      let &statusline = s:_statusline
+      unlet s:_statusline
+    endif
   endif
   if s:lightline.enable.tabline
+    let s:_tabline = &tabline
     set tabline=%!lightline#tabline()
   else
-    let &tabline = get(s:, '_tabline', '')
+    if exists("s:_tabline")
+      let &tabline = s:_tabline
+      unlet s:_tabline
+    endif
   endif
   for f in values(s:lightline.component_function)
     silent! call call(f, [])


### PR DESCRIPTION
Hi, 

This PR addresses an issue I mentioned in #687. 
1. Plugin manager loads lightline. My config disables tabline with  `g:lightline.enable.tabline==0`.  Lightline saves `&tabline` anyway
2. Plugin manager loads a different tabline plugin which customizes `&tabline`
3. Calling `lightline#disable()` restores the (wrong) saved tabline

Thanks again for your work.