### PR TITLE
Do not reset tabline or statusline if they are not used

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -66,7 +66,14 @@ function! lightline#enable() abort
 endfunction
 
 function! lightline#disable() abort
-  let [&statusline, &tabline] = [get(s:, '_statusline', ''), get(s:, '_tabline', '')]
+  if exists('s:_statusline')
+    let &statusline = s:_statusline
+    unlet s:_statusline
+  endif
+  if exists("s:_tabline")
+    let &tabline = s:_tabline
+    unlet s:_tabline
+  endif
   for t in range(1, tabpagenr('$'))
     for n in range(1, tabpagewinnr(t, '$'))
       call settabwinvar(t, n, '&statusline', '')
@@ -172,16 +179,19 @@ function! lightline#init() abort
       break
     endif
   endfor
-  if !exists('s:_statusline')
+  if s:lightline.enable.statusline && !exists('s:_statusline')
     let s:_statusline = &statusline
   endif
-  if !exists('s:_tabline')
-    let s:_tabline = &tabline
-  endif
   if s:lightline.enable.tabline
+    if !exists('s:_tabline')
+      let s:_tabline = &tabline
+    endif
     set tabline=%!lightline#tabline()
   else
-    let &tabline = get(s:, '_tabline', '')
+    if exists("s:_tabline")
+      let &tabline = s:_tabline
+      unlet s:_tabline
+    endif
   endif
   for f in values(s:lightline.component_function)
     silent! call call(f, [])

--- a/test/toggle.vim
+++ b/test/toggle.vim
@@ -49,3 +49,15 @@ function! s:suite.toggle()
   call s:assert.not_equals(&statusline, '')
   call s:assert.not_equals(&tabline, '')
 endfunction
+
+function! s:suite.notab_toggle()
+  let g:lightline = { 'enable': { 'tabline': 0 } }
+  call lightline#init()
+  call lightline#toggle()
+  set tabline=ASDF
+  call lightline#toggle()
+  let check_tabline = &tabline
+  set tabline=
+  call s:assert.equals(check_tabline, 'ASDF')
+endfunction
+


### PR DESCRIPTION
Hi. 

Resubmitting #690 with new a testcase. The first commit adds a new testcase demonstrating the issue from #687.  The second commit resolves updates lightline to resolve it.

**Problem overview:**
 1. Plugin manager loads lightline. My config disables tabline with  `g:lightline.enable.tabline==0`.  Lightline saves `&tabline` anyway
 2. Plugin manager loads a different tabline plugin which customizes `&tabline`
 3. Calling `lightline#disable()` restores the (wrong) saved tabline

Thanks again for your work.