### PR TITLE
fix(neovim): floating windows can now have statuslines

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -21,22 +21,28 @@ function! lightline#update() abort
     let w = winnr()
     let s = winnr('$') == 1 && w > 0 ? [lightline#statusline(0)] : [lightline#statusline(0), lightline#statusline(1)]
     for n in range(1, winnr('$'))
-      call setwinvar(n, '&statusline', s[n!=w])
+      if !s:skip(n)
+        call setwinvar(n, '&statusline', s[n!=w])
+      endif
     endfor
   endif
 endfunction
 
-if exists('*nvim_win_get_config')
-  function! s:skip() abort
-    return !nvim_win_get_config(0).focusable
-  endfunction
-elseif exists('*win_gettype')
-  function! s:skip() abort " Vim 8.2.0257 (00f3b4e007), 8.2.0991 (0fe937fd86), 8.2.0996 (40a019f157)
-    return win_gettype() ==# 'popup' || win_gettype() ==# 'autocmd'
+if exists('*win_gettype')
+  function! s:skip(...) abort " Vim 8.2.0257 (00f3b4e007), 8.2.0991 (0fe937fd86), 8.2.0996 (40a019f157)
+    let l:wintype = call('win_gettype', a:000)
+    return l:wintype ==# 'popup' || l:wintype ==# 'autocmd'
   endfunction
 else
-  function! s:skip() abort
-    return &buftype ==# 'popup'
+  function! s:skip(...) abort
+    let l:winid
+    if a:0 > 0
+      let l:buftype = getbufvar(win_getbuf(a:1), '&buftype')
+    else
+      let l:buftype = &buftype
+    endif
+
+    return l:buftype ==# 'popup'
   endfunction
 endif
 


### PR DESCRIPTION
This pull request is necessary due to recent changes in Neovim nightly which introduced native support for statuslines on floating windows (e.g., neovim/neovim#36521). I could observe statuslines being drawn on telescope prompts and notify.nvim prompts in nightly due to that commit.

It is now not reliable to check for `nvim_win_get_config(0).focusable` at all, because floating windows are focusable by default, and that will cause the statusline to be drawn under them.
Also, we need to check for skippability of windows before calling `setwinvar(n, '&statusline', s[n!=w])` to prevent a statusline being drawn on floating windows that are not in focus, so I added an optional winid variable to the `s:skip` function.