### PR TITLE
Add ability for user-configured advanced mode name

### DIFF
--- a/autoload/lightline.vim
+++ b/autoload/lightline.vim
@@ -215,7 +215,19 @@ function! lightline#palette() abort
 endfunction
 
 function! lightline#mode() abort
-  return get(s:lightline.mode_map, mode(), '')
+  let mode = mode(1)
+  let mode_name = get(s:lightline.mode_map, mode, '')
+  while mode_name == '' && len(mode) > 1
+    mode = mode[:-2]
+    mode_name = get(s:lightline.mode_map, mode, '')
+  endwhile
+  " If, somehow, we got to a single-char mode(1) string and we DON'T have a
+  " result (should be impossible!), fall back to the legacy mode(0)
+  " (functionally equivalent to `mode(1)[0]`) behaviour:
+  if mode_name == ''
+    mode_name = get(s:lightline.mode_map, mode(), '')
+  endif
+  return mode_name
 endfunction
 
 let s:mode = ''

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -245,7 +245,7 @@ OPTIONS						*lightline-option*
 		A dictionary of names for the modes. The full mode string from
 		mode(|non-zero-arg|) is checked, and the last character(s) are
 		removed until a match is found. For example, if the mode is
-		'niI', lightline.nvim will check if there is a name for 'niI'
+		'niI', lightline.vim will check if there is a name for 'niI'
 		in the map, then 'ni', finally falling back to 'n'. See |mode()|.
 		The default values are:
 >

--- a/doc/lightline.txt
+++ b/doc/lightline.txt
@@ -242,9 +242,12 @@ OPTIONS						*lightline-option*
 		powerline theme.
 
 	g:lightline.mode_map			*g:lightline.mode_map*
-		A dictionary of names for the modes. The keys are the return
-		values of |mode()|.
-		The default value is:
+		A dictionary of names for the modes. The full mode string from
+		mode(|non-zero-arg|) is checked, and the last character(s) are
+		removed until a match is found. For example, if the mode is
+		'niI', lightline.nvim will check if there is a name for 'niI'
+		in the map, then 'ni', finally falling back to 'n'. See |mode()|.
+		The default values are:
 >
 		let g:lightline.mode_map = {
 		    \ 'n' : 'NORMAL',
@@ -318,7 +321,7 @@ Exposed functions for lightline.vim.
 	lightline#link([mode])			*lightline#link()*
 		Creates links of the highlight groups for the active window.
 		This function accepts an optional argument. It should be one
-		of the return value of |mode()|.
+		of the return values of |mode()|.
 
 	lightline#highlight()			*lightline#highlight()*
 		Set the highlight groups.


### PR DESCRIPTION
`mode()` by default returns a single character for the mode, but `mode(v:true)` will return a full string. See [`:h mode()`](https://vimhelp.org/builtin.txt.html#mode%28%29):
> Return a string that indicates the current mode. If `{expr}` is supplied and it evaluates to a non-zero Number or a non-empty String (non-zero-arg), then the full mode is returned, otherwise only the first letter is returned. \[…\]
> 
>     n	    Normal
>     no	    Operator-pending
>     nov	    Operator-pending (forced characterwise o_v)
>     […]
> 
> ***Note*** that in the future more modes and more specific modes may be added. It's better not to compare the whole string but only the leading character(s).

As per that last recommendation, I implemented an algorithm such that the user can override `g:lightline.mode_map` to include a mode name string for a given full `mode(v:true)` output, or a lower level (e.g. the name string for `'ni'` will apply to `'niI'`, `'niR'`, and `'niV'` if none of the resp. are set). Searching backwards will eventually land back at a single-char `mode(v:false)` string, which is functionally equivalent to the old behaviour.

I've added fallbacks to the old behaviour after my algorithm (which in turn always fell back to `''`), and as such this should be 100% backwards-compatible. I haven't decided to add any `mode_map` names yet, but for example, `<C-o>` in Insert mode in vanilla Vim gives the status `-- (insert) --` instead of `-- INSERT --`, which could be implemented (by the user or by lightline.vim) as:
```vim
    'niI': '-- (insert) --'
```
(Currently lightline.vim shows `NORMAL` when in this state)

Documentation also included!